### PR TITLE
Generate another  for the react dev server

### DIFF
--- a/frontend/config/webpack.config.js
+++ b/frontend/config/webpack.config.js
@@ -516,6 +516,31 @@ module.exports = function(webpackEnv) {
           {},
           {
             inject: true,
+            template: paths.appHtml
+          },
+          isEnvProduction
+            ? {
+                minify: {
+                  removeComments: true,
+                  collapseWhitespace: true,
+                  removeRedundantAttributes: true,
+                  useShortDoctype: true,
+                  removeEmptyAttributes: true,
+                  removeStyleLinkTypeAttributes: true,
+                  keepClosingSlash: true,
+                  minifyJS: true,
+                  minifyCSS: true,
+                  minifyURLs: true
+                }
+              }
+            : undefined
+        )
+      ),
+      new HtmlWebpackPlugin(
+        Object.assign(
+          {},
+          {
+            inject: true,
             template: paths.appHtml,
             filename: "../../templates/index.html"
           },


### PR DESCRIPTION
This is not a "correct" fix and instead feels more like a hack but it seems to fix the problem. This change means that we now generate two `index.html` files at the same time. One for the react-dev server and one for the flask backend.