### PR TITLE
Removed a function that is not for the button in the modal footer

### DIFF
--- a/frontend/src/components/custom-modal/custom-modal.component.jsx
+++ b/frontend/src/components/custom-modal/custom-modal.component.jsx
@@ -26,12 +26,7 @@ const CustomModal = ({ color, title, header, children, form }) => {
         ) : null}
         <Modal.Body>{children}</Modal.Body>
         <Modal.Footer>
-          <Button
-            variant="info"
-            onClick={handleClose}
-            type="submit"
-            form={form}
-          >
+          <Button variant="info" type="submit" form={form}>
             {title}
           </Button>
         </Modal.Footer>


### PR DESCRIPTION
The custom modal component is used when users create a room or type a password to join a room.
So there is no need for the button (create a room / join) to have close function.

＋There is 'x' button in the modal header. 